### PR TITLE
Create Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,11 @@
+FROM lefant/python3-keras
+
+# Run the resulting docker image with nvidia-docker.
+# Note, the following files should have already been extracted: base_generator.net  google_net.net  style2paints.net
+
+RUN pip3 install chainer cupy bottle gevent h5py opencv-python
+RUN git clone https://github.com/lllyasviel/style2paints.git
+COPY *.net style2paints/server/
+RUN apt-get install -y libcudnn6-dev=6.0.21-1+cuda8.0
+WORKDIR style2paints/server/
+CMD python3 server.py # Runs on port 8000


### PR DESCRIPTION
Adding a dockerfile to make it easier for people to use this code.

Note that it currently crashes with a CUDNN error when running the style algorithm:

```
Traceback (most recent call last):
  File "/usr/local/lib/python3.5/dist-packages/bottle.py", line 862, in _handle
    return route.call(**args)
  File "/usr/local/lib/python3.5/dist-packages/bottle.py", line 1740, in wrapper
    rv = callback(*a, **ka)
  File "server.py", line 291, in do_paint
    chainer.cuda.to_gpu(reference, chainer_ID))
  File "/usr/lib/python3.5/contextlib.py", line 77, in __exit__
    self.gen.throw(type, value, traceback)
  File "/usr/local/lib/python3.5/dist-packages/chainer/configuration.py", line 125, in using_config
    yield
  File "server.py", line 291, in do_paint
    chainer.cuda.to_gpu(reference, chainer_ID))
  File "/usr/lib/python3.5/contextlib.py", line 77, in __exit__
    self.gen.throw(type, value, traceback)
  File "/usr/local/lib/python3.5/dist-packages/chainer/configuration.py", line 125, in using_config
    yield
  File "server.py", line 291, in do_paint
    chainer.cuda.to_gpu(reference, chainer_ID))
  File "server.py", line 66, in forward
    h = F.max_pooling_2d(F.relu(self.norm1(self.conv1(x))), 3, stride=2, pad=1) # 64 * 57 * 57
  File "/usr/local/lib/python3.5/dist-packages/chainer/links/connection/convolution_2d.py", line 154, in __call__
    x, self.W, self.b, self.stride, self.pad)
  File "/usr/local/lib/python3.5/dist-packages/chainer/functions/connection/convolution_2d.py", line 437, in convolution_2d
    return func(x, W)
  File "/usr/local/lib/python3.5/dist-packages/chainer/function.py", line 201, in __call__
    outputs = self.forward(in_data)
  File "/usr/local/lib/python3.5/dist-packages/chainer/function.py", line 329, in forward
    return self.forward_gpu(inputs)
  File "/usr/local/lib/python3.5/dist-packages/chainer/functions/connection/convolution_2d.py", line 142, in forward_gpu
    workspace_size)
  File "cupy/cuda/cudnn.pyx", line 666, in cupy.cuda.cudnn.getConvolutionForwardAlgorithm
  File "cupy/cuda/cudnn.pyx", line 676, in cupy.cuda.cudnn.getConvolutionForwardAlgorithm
  File "cupy/cuda/cudnn.pyx", line 417, in cupy.cuda.cudnn.check_status
cupy.cuda.cudnn.CuDNNError: CUDNN_STATUS_BAD_PARAM: b'CUDNN_STATUS_BAD_PARAM'
```