### PR TITLE
fix(sec): upgrade keras to 2.6.0rc3

### DIFF
--- a/V4/s2p_v4_server/requirements.txt
+++ b/V4/s2p_v4_server/requirements.txt
@@ -1,7 +1,7 @@
 opencv-contrib-python==4.1.0.25
 tensorflow_gpu==1.14.0
 bottle==0.12.10
-keras==2.2.5
+keras==2.6.0rc3
 scikit-learn==0.23.1
 scikit-image==0.14.5
 llvmlite==0.36.0


### PR DESCRIPTION
### What happened？
There are 1 security vulnerabilities found in keras 2.2.5
- [MPS-2022-14959](https://www.oscs1024.com/hd/MPS-2022-14959)


### What did I do？
Upgrade keras from 2.2.5 to 2.6.0rc3 for vulnerability fix

### What did you expect to happen？
Ideally, no insecure libs should be used.

### The specification of the pull request
[PR Specification](https://www.oscs1024.com/docs/pr-specification/) from OSCS