### PR TITLE
fix(sec): upgrade scikit-learn to 0.24.2

### DIFF
--- a/V4/s2p_v4_server/requirements.txt
+++ b/V4/s2p_v4_server/requirements.txt
@@ -2,7 +2,7 @@ opencv-contrib-python==4.1.0.25
 tensorflow_gpu==1.14.0
 bottle==0.12.10
 keras==2.2.5
-scikit-learn==0.23.1
+scikit-learn==0.24.2
 scikit-image==0.14.5
 llvmlite==0.36.0
 numba==0.53.1


### PR DESCRIPTION
### What happened？
There are 1 security vulnerabilities found in scikit-learn 0.23.1
- [MPS-2022-15126](https://www.oscs1024.com/hd/MPS-2022-15126)


### What did I do？
Upgrade scikit-learn from 0.23.1 to 0.24.2 for vulnerability fix

### What did you expect to happen？
Ideally, no insecure libs should be used.

### How can we automate the detection of these types of issues?
By using the [GitHub Actions](https://github.com/murphysecurity/actions) configurations provided by murphysec, we can conduct automatic code security checks in our CI pipeline.

### The specification of the pull request
[PR Specification](https://www.oscs1024.com/docs/pr-specification/) from OSCS